### PR TITLE
WSOL Instant Withdrawal

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,14 @@ pnpm run build
 ```
 
 For local development, you need to import it as a dependency like this: `"@solana/spl-stake-pool": "file:../stake-pool-v2/clients/js-legacy",`
+
+## CLI
+
+```
+cd clients/cli
+cargo install --path . --locked
+# deposit with session
+spl-stake-pool --url https://testnet.fogo.io --program-id SPRe2ae9JQhySheYsSANX6M8tUZLt5bQonnBJ6Wu6Ud deposit-wsol-with-session 4yoj9HDiL2pujuh2ME5MJJ6roLseTAkFqLmA4SrG7Yi9 0.1
+# withdraw with session
+spl-stake-pool --url https://testnet.fogo.io --program-id SPRe2ae9JQhySheYsSANX6M8tUZLt5bQonnBJ6Wu6Ud withdraw-wsol-with-session 4yoj9HDiL2pujuh2ME5MJJ6roLseTAkFqLmA4SrG7Yi9 0.1
+```

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -1654,6 +1654,12 @@ fn command_withdraw_wsol_with_session(
         find_withdraw_authority_program_address(&config.stake_pool_program_id, stake_pool_address)
             .0;
 
+    // Derive the program signer PDA
+    let (program_signer, _bump) = Pubkey::find_program_address(
+        &[PROGRAM_SIGNER_SEED], // PROGRAM_SIGNER_SEED from your processor
+        &config.stake_pool_program_id,
+    );
+
     // Build the withdraw_wsol_with_session instruction
     let withdraw_instruction = if let Some(withdraw_authority) = config.funding_authority.as_ref() {
         let expected_sol_withdraw_authority = stake_pool.sol_withdraw_authority.ok_or_else(|| {
@@ -1684,6 +1690,7 @@ fn command_withdraw_wsol_with_session(
             &user_pubkey,
             &user_pubkey,
             &system_program::id(),
+            &program_signer,
             pool_amount_tokens,
         )
     } else {
@@ -1703,6 +1710,7 @@ fn command_withdraw_wsol_with_session(
             &config.fee_payer.pubkey(),
             &user_pubkey,
             &system_program::id(),
+            &program_signer,
             pool_amount_tokens,
         )
     };

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -1650,22 +1650,6 @@ fn command_withdraw_wsol_with_session(
         &mut total_rent_free_balances,
     );
 
-    // Create ephemeral transfer authority for spending pool tokens
-    let user_transfer_authority = Keypair::new();
-    signers.push(&user_transfer_authority);
-
-    // Approve spending pool tokens
-    instructions.push(
-        spl_token_2022::instruction::approve(
-            &stake_pool.token_program_id,
-            &pool_token_account,
-            &user_transfer_authority.pubkey(),
-            &user_pubkey,
-            &[],
-            pool_amount_tokens,
-        )?,
-    );
-
     let pool_withdraw_authority =
         find_withdraw_authority_program_address(&config.stake_pool_program_id, stake_pool_address)
             .0;
@@ -1688,7 +1672,7 @@ fn command_withdraw_wsol_with_session(
             &config.stake_pool_program_id,
             stake_pool_address,
             &pool_withdraw_authority,
-            &user_transfer_authority.pubkey(),
+            &user_pubkey,
             &pool_token_account,
             &stake_pool.reserve_stake,
             &user_wsol_account,
@@ -1707,7 +1691,7 @@ fn command_withdraw_wsol_with_session(
             &config.stake_pool_program_id,
             stake_pool_address,
             &pool_withdraw_authority,
-            &user_transfer_authority.pubkey(),
+            &user_pubkey,
             &pool_token_account,
             &stake_pool.reserve_stake,
             &user_wsol_account,
@@ -1716,7 +1700,7 @@ fn command_withdraw_wsol_with_session(
             &stake_pool.token_program_id,
             None,
             &spl_token::native_mint::id(),
-            &user_pubkey,
+            &config.fee_payer.pubkey(),
             &user_pubkey,
             &system_program::id(),
             pool_amount_tokens,

--- a/clients/js-legacy/src/index.ts
+++ b/clients/js-legacy/src/index.ts
@@ -496,19 +496,25 @@ export async function withdrawWsolWithSession(
     ),
   );
 
-  // Create ephemeral transfer authority for spending pool tokens
-  const userTransferAuthority = Keypair.generate();
-  signers.push(userTransferAuthority);
-
-  // Approve spending pool tokens
-  instructions.push(
-    createApproveInstruction(
-      poolTokenAccount,
-      userTransferAuthority.publicKey,
-      userWallet, // The actual user needs to approve
-      poolTokensLamports,
-    ),
+  // Derive the program signer PDA
+  const [programSigner] = PublicKey.findProgramAddressSync(
+    [Buffer.from('fogo_session_program_signer')], // PROGRAM_SIGNER_SEED: https://github.com/fogo-foundation/fogo-sessions/blob/8b00bdfb214c0f797d8dd22fc24f813801a8a191/packages/sessions-sdk-rs/src/token/mod.rs#L5
+    stakePoolProgramId,
   );
+
+  // // Create ephemeral transfer authority for spending pool tokens
+  // const userTransferAuthority = Keypair.generate();
+  // signers.push(userTransferAuthority);
+
+  // // Approve spending pool tokens
+  // instructions.push(
+  //   createApproveInstruction(
+  //     poolTokenAccount,
+  //     userTransferAuthority.publicKey,
+  //     userWallet, // The actual user needs to approve
+  //     poolTokensLamports,
+  //   ),
+  // );
 
   const withdrawAuthority = await findWithdrawAuthorityProgramAddress(
     stakePoolProgramId,
@@ -521,7 +527,8 @@ export async function withdrawWsolWithSession(
       programId: stakePoolProgramId,
       stakePool: stakePoolAddress,
       withdrawAuthority,
-      userTransferAuthority: userTransferAuthority.publicKey,
+      //userTransferAuthority: userTransferAuthority.publicKey,
+      userTransferAuthority: signerOrSession,
       poolTokensFrom: poolTokenAccount,
       reserveStake: stakePool.reserveStake,
       userWsolAccount,
@@ -532,6 +539,7 @@ export async function withdrawWsolWithSession(
       wsolMint: NATIVE_MINT,
       feePayer: paymaster ?? signerOrSession,
       userOwner: userWallet,
+      programSigner,
       poolTokens: poolTokensLamports,
     }),
   );

--- a/clients/js-legacy/src/index.ts
+++ b/clients/js-legacy/src/index.ts
@@ -449,6 +449,100 @@ export async function depositWsolWithSession(
 }
 
 /**
+ * Creates instructions required to withdraw WSOL from a stake pool using sessions.
+ */
+export async function withdrawWsolWithSession(
+  connection: Connection,
+  stakePoolAddress: PublicKey,
+  signerOrSession: PublicKey, // Either the session public key or user's wallet
+  userWallet: PublicKey, // The actual user's wallet (extracted from session or same as signer)
+  poolTokens: number,
+  poolTokenAccount?: PublicKey,
+  solWithdrawAuthority?: PublicKey,
+  paymaster?: PublicKey,
+) {
+  const stakePoolAccount = await getStakePoolAccount(connection, stakePoolAddress);
+  const stakePoolProgramId = getStakePoolProgramId(connection.rpcEndpoint);
+  const stakePool = stakePoolAccount.account.data;
+
+  // Default pool token account to user's associated token account
+  if (!poolTokenAccount) {
+    poolTokenAccount = getAssociatedTokenAddressSync(stakePool.poolMint, userWallet);
+  }
+
+  // Check pool token balance
+  const tokenAccount = await getAccount(connection, poolTokenAccount);
+  const poolTokensLamports = solToLamports(poolTokens);
+  
+  if (tokenAccount.amount < poolTokensLamports) {
+    throw new Error(
+      `Not enough pool token balance to withdraw ${poolTokens} pool tokens.\nMaximum withdraw amount is ${lamportsToSol(tokenAccount.amount)} pool tokens.`,
+    );
+  }
+
+  // User's WSOL ATA
+  const userWsolAccount = getAssociatedTokenAddressSync(NATIVE_MINT, userWallet);
+
+  const instructions: TransactionInstruction[] = [];
+  const signers: Signer[] = [];
+
+  // Create WSOL ATA if it doesn't exist
+  instructions.push(
+    createAssociatedTokenAccountIdempotentInstruction(
+      paymaster ?? signerOrSession, // Payer (could be session or user)
+      userWsolAccount,
+      userWallet, // Owner is always the actual user
+      NATIVE_MINT,
+    ),
+  );
+
+  // Create ephemeral transfer authority for spending pool tokens
+  const userTransferAuthority = Keypair.generate();
+  signers.push(userTransferAuthority);
+
+  // Approve spending pool tokens
+  instructions.push(
+    createApproveInstruction(
+      poolTokenAccount,
+      userTransferAuthority.publicKey,
+      userWallet, // The actual user needs to approve
+      poolTokensLamports,
+    ),
+  );
+
+  const withdrawAuthority = await findWithdrawAuthorityProgramAddress(
+    stakePoolProgramId,
+    stakePoolAddress,
+  );
+
+  // Build the withdraw_wsol_with_session instruction
+  instructions.push(
+    StakePoolInstruction.buildWithdrawWsolWithSessionInstruction({
+      programId: stakePoolProgramId,
+      stakePool: stakePoolAddress,
+      withdrawAuthority,
+      userTransferAuthority: userTransferAuthority.publicKey,
+      poolTokensFrom: poolTokenAccount,
+      reserveStake: stakePool.reserveStake,
+      userWsolAccount,
+      managerFeeAccount: stakePool.managerFeeAccount,
+      poolMint: stakePool.poolMint,
+      tokenProgramId: TOKEN_PROGRAM_ID,
+      solWithdrawAuthority,
+      wsolMint: NATIVE_MINT,
+      feePayer: paymaster ?? signerOrSession,
+      userOwner: userWallet,
+      poolTokens: poolTokensLamports,
+    }),
+  );
+
+  return {
+    instructions,
+    signers,
+  };
+}
+
+/**
  * Creates instructions required to withdraw stake from a stake pool.
  */
 export async function withdrawStake(

--- a/clients/js-legacy/src/instructions.ts
+++ b/clients/js-legacy/src/instructions.ts
@@ -382,6 +382,7 @@ export type WithdrawWsolWithSessionParams = {
   wsolMint: PublicKey;
   feePayer: PublicKey;
   userOwner: PublicKey;
+  programSigner: PublicKey;
   poolTokens: number;
 };
 
@@ -1113,7 +1114,7 @@ export class StakePoolInstruction {
     const keys = [
       { pubkey: params.stakePool, isSigner: false, isWritable: true },
       { pubkey: params.withdrawAuthority, isSigner: false, isWritable: false },
-      { pubkey: params.userTransferAuthority, isSigner: true, isWritable: false },
+      { pubkey: params.userTransferAuthority, isSigner: true, isWritable: true },
       { pubkey: params.poolTokensFrom, isSigner: false, isWritable: true },
       { pubkey: params.reserveStake, isSigner: false, isWritable: true },
       { pubkey: params.userWsolAccount, isSigner: false, isWritable: true },
@@ -1125,6 +1126,15 @@ export class StakePoolInstruction {
       { pubkey: params.tokenProgramId, isSigner: false, isWritable: false },
     ];
 
+    keys.push(
+      { pubkey: params.wsolMint, isSigner: false, isWritable: false },
+      { pubkey: params.feePayer, isSigner: true, isWritable: true },
+      { pubkey: params.userOwner, isSigner: false, isWritable: false },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+      { pubkey: params.programSigner, isSigner: false, isWritable: true },
+    );
+
+    // Optional SOL withdraw authority (needs to be at the end since it is not always present)
     if (params.solWithdrawAuthority) {
       keys.push({
         pubkey: params.solWithdrawAuthority,
@@ -1132,13 +1142,6 @@ export class StakePoolInstruction {
         isWritable: false,
       });
     }
-
-    keys.push(
-      { pubkey: params.wsolMint, isSigner: false, isWritable: false },
-      { pubkey: params.feePayer, isSigner: true, isWritable: true },
-      { pubkey: params.userOwner, isSigner: false, isWritable: false },
-      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
-    );
 
     const type = STAKE_POOL_INSTRUCTION_LAYOUTS.WithdrawWsolWithSession;
     const data = encodeData(type, { poolTokens: params.poolTokens });

--- a/clients/js-legacy/src/instructions.ts
+++ b/clients/js-legacy/src/instructions.ts
@@ -39,7 +39,8 @@ export type StakePoolInstructionType =
   | 'Redelegate'
   | 'AddValidatorToPool'
   | 'RemoveValidatorFromPool'
-  | 'DepositWsolWithSession';
+  | 'DepositWsolWithSession'
+  | 'WithdrawWsolWithSession';
 
 // 'UpdateTokenMetadata' and 'CreateTokenMetadata' have dynamic layouts
 
@@ -214,6 +215,13 @@ export const STAKE_POOL_INSTRUCTION_LAYOUTS: {
       BufferLayout.ns64('lamports'),
     ]),
   },
+  WithdrawWsolWithSession: {
+    index: 28,
+    layout: BufferLayout.struct<any>([
+      BufferLayout.u8('instruction'),
+      BufferLayout.ns64('poolTokens'),
+    ]),
+  },
 });
 
 /**
@@ -353,6 +361,27 @@ export type WithdrawSolParams = {
   solWithdrawAuthority?: PublicKey | undefined;
   managerFeeAccount: PublicKey;
   poolMint: PublicKey;
+  poolTokens: number;
+};
+
+/**
+ * Withdraw WSOL with session instruction params
+ */
+export type WithdrawWsolWithSessionParams = {
+  programId: PublicKey;
+  stakePool: PublicKey;
+  withdrawAuthority: PublicKey;
+  userTransferAuthority: PublicKey;
+  poolTokensFrom: PublicKey;
+  reserveStake: PublicKey;
+  userWsolAccount: PublicKey;
+  managerFeeAccount: PublicKey;
+  poolMint: PublicKey;
+  tokenProgramId: PublicKey;
+  solWithdrawAuthority?: PublicKey;
+  wsolMint: PublicKey;
+  feePayer: PublicKey;
+  userOwner: PublicKey;
   poolTokens: number;
 };
 
@@ -1073,6 +1102,50 @@ export class StakePoolInstruction {
     return new TransactionInstruction({
       programId: programId ?? STAKE_POOL_PROGRAM_ID,
       keys,
+      data,
+    });
+  }
+
+  /**
+   * Helper function to build the withdraw_wsol_with_session instruction
+   */
+  static buildWithdrawWsolWithSessionInstruction(params: WithdrawWsolWithSessionParams): TransactionInstruction {
+    const keys = [
+      { pubkey: params.stakePool, isSigner: false, isWritable: true },
+      { pubkey: params.withdrawAuthority, isSigner: false, isWritable: false },
+      { pubkey: params.userTransferAuthority, isSigner: true, isWritable: false },
+      { pubkey: params.poolTokensFrom, isSigner: false, isWritable: true },
+      { pubkey: params.reserveStake, isSigner: false, isWritable: true },
+      { pubkey: params.userWsolAccount, isSigner: false, isWritable: true },
+      { pubkey: params.managerFeeAccount, isSigner: false, isWritable: true },
+      { pubkey: params.poolMint, isSigner: false, isWritable: true },
+      { pubkey: SYSVAR_CLOCK_PUBKEY, isSigner: false, isWritable: false },
+      { pubkey: SYSVAR_STAKE_HISTORY_PUBKEY, isSigner: false, isWritable: false },
+      { pubkey: StakeProgram.programId, isSigner: false, isWritable: false },
+      { pubkey: params.tokenProgramId, isSigner: false, isWritable: false },
+    ];
+
+    if (params.solWithdrawAuthority) {
+      keys.push({
+        pubkey: params.solWithdrawAuthority,
+        isSigner: true,
+        isWritable: false,
+      });
+    }
+
+    keys.push(
+      { pubkey: params.wsolMint, isSigner: false, isWritable: false },
+      { pubkey: params.feePayer, isSigner: true, isWritable: true },
+      { pubkey: params.userOwner, isSigner: false, isWritable: false },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    );
+
+    const type = STAKE_POOL_INSTRUCTION_LAYOUTS.WithdrawWsolWithSession;
+    const data = encodeData(type, { poolTokens: params.poolTokens });
+
+    return new TransactionInstruction({
+      keys,
+      programId: params.programId,
       data,
     });
   }

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -786,6 +786,7 @@ pub enum StakePoolInstruction {
     ///  14. `[s, w]` Fee payer (session or wallet) for idempotent ATA creation
     ///  15. `[]` User owner (system account that owns the WSOL ATA)
     ///  16. `[]` System Program
+    ///  17. `[w]` Program signer PDA (only present in WSOL path)
     WithdrawWsolWithSession(u64),
 }
 
@@ -2520,6 +2521,7 @@ pub fn withdraw_wsol_with_session(
     fee_payer: &Pubkey,
     user_owner: &Pubkey,
     system_program_id: &Pubkey,
+    program_signer: &Pubkey,
     pool_tokens_in: u64,
 ) -> Instruction {
     // Same account order as WithdrawSol, with the destination replaced by the
@@ -2543,12 +2545,13 @@ pub fn withdraw_wsol_with_session(
     accounts.push(AccountMeta::new(*fee_payer, true));
     accounts.push(AccountMeta::new_readonly(*user_owner, false));
     accounts.push(AccountMeta::new_readonly(*system_program_id, false));
+    accounts.push(AccountMeta::new(*program_signer, false));
 
     // Optional SOL withdraw authority (needs to be at the end)
     if let Some(sol_withdraw_authority) = sol_withdraw_authority {
         accounts.push(AccountMeta::new_readonly(*sol_withdraw_authority, true));
     }
-    
+
     Instruction {
         program_id: *program_id,
         accounts,

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -2538,13 +2538,17 @@ pub fn withdraw_wsol_with_session(
         AccountMeta::new_readonly(stake::program::id(), false),
         AccountMeta::new_readonly(*token_program_id, false),
     ];
-    if let Some(sol_withdraw_authority) = sol_withdraw_authority {
-        accounts.push(AccountMeta::new_readonly(*sol_withdraw_authority, true));
-    }
+
     accounts.push(AccountMeta::new_readonly(*wsol_mint, false));
     accounts.push(AccountMeta::new(*fee_payer, true));
     accounts.push(AccountMeta::new_readonly(*user_owner, false));
     accounts.push(AccountMeta::new_readonly(*system_program_id, false));
+
+    // Optional SOL withdraw authority (needs to be at the end)
+    if let Some(sol_withdraw_authority) = sol_withdraw_authority {
+        accounts.push(AccountMeta::new_readonly(*sol_withdraw_authority, true));
+    }
+    
     Instruction {
         program_id: *program_id,
         accounts,

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -762,6 +762,28 @@ pub enum StakePoolInstruction {
         /// amount of lamports to deposit
         lamports: u64,
     },
+
+    /// Withdraw WSOL directly to the user's WSOL token account (native mint ATA),
+    /// using SOL from the reserve. Burns pool tokens at the same price/fees as
+    /// `WithdrawSol`, then unwraps to WSOL in-place by `sync_native`.
+    ///
+    /// Accounts (similar to `WithdrawSol`, with destination replaced):
+    ///   0. `[w]` Stake pool
+    ///   1. `[]` Stake pool withdraw authority
+    ///   2. `[s]` User transfer authority, for pool token account
+    ///   3. `[w]` User account to burn pool tokens
+    ///   4. `[w]` Reserve stake account, to withdraw SOL
+    ///   5. `[w]` User WSOL token account (ATA for native mint, So111...); will
+    ///           receive lamports and be `sync_native`-ed to reflect WSOL
+    ///   6. `[w]` Account to receive pool fee tokens
+    ///   7. `[w]` Pool token mint account
+    ///   8. `[]` Clock sysvar
+    ///   9. `[]` Stake history sysvar
+    ///  10. `[]` Stake program account
+    ///  11. `[]` Token program id
+    ///  12. `[]` WSOL mint (native mint, So111…)
+    ///  13. `[s]` (Optional) Stake pool SOL withdraw authority
+    WithdrawWsolWithSession(u64),
 }
 
 /// Creates an `Initialize` instruction.
@@ -2476,6 +2498,52 @@ pub fn withdraw_sol(
         pool_tokens_in,
         None,
     )
+}
+
+/// Creates instruction required to withdraw WSOL directly to the user's WSOL ATA.
+pub fn withdraw_wsol_with_session(
+    program_id: &Pubkey,
+    stake_pool: &Pubkey,
+    stake_pool_withdraw_authority: &Pubkey,
+    user_transfer_authority: &Pubkey,
+    pool_tokens_from: &Pubkey,
+    reserve_stake_account: &Pubkey,
+    user_wsol_account: &Pubkey,
+    manager_fee_account: &Pubkey,
+    pool_mint: &Pubkey,
+    token_program_id: &Pubkey,
+    wsol_mint: &Pubkey,
+    pool_tokens_in: u64,
+    sol_withdraw_authority: Option<&Pubkey>,
+) -> Instruction {
+    // Same account order as WithdrawSol, with the destination replaced by the
+    // user's WSOL token account, and with an extra readonly WSOL mint.
+    let mut accounts = vec![
+        AccountMeta::new(*stake_pool, false),
+        AccountMeta::new_readonly(*stake_pool_withdraw_authority, false),
+        AccountMeta::new_readonly(*user_transfer_authority, true),
+        AccountMeta::new(*pool_tokens_from, false),
+        AccountMeta::new(*reserve_stake_account, false),
+        AccountMeta::new(*user_wsol_account, false),
+        AccountMeta::new(*manager_fee_account, false),
+        AccountMeta::new(*pool_mint, false),
+        AccountMeta::new_readonly(sysvar::clock::id(), false),
+        AccountMeta::new_readonly(sysvar::stake_history::id(), false),
+        AccountMeta::new_readonly(stake::program::id(), false),
+        AccountMeta::new_readonly(*token_program_id, false),
+        AccountMeta::new_readonly(*wsol_mint, false),
+    ];
+    if let Some(sol_withdraw_authority) = sol_withdraw_authority {
+        accounts.push(AccountMeta::new_readonly(*sol_withdraw_authority, true));
+    }
+    Instruction {
+        program_id: *program_id,
+        accounts,
+        data: borsh::to_vec(&StakePoolInstruction::WithdrawWsolWithSession(
+            pool_tokens_in,
+        ))
+        .unwrap(),
+    }
 }
 
 /// Creates instruction required to withdraw SOL directly from a stake pool with

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -3272,137 +3272,137 @@ impl Processor {
     /// Ensures the user's WSOL ATA exists (creating it if missing), delegates
     /// to `process_withdraw_sol`, then performs `sync_native`.
     #[inline(never)]
-fn process_withdraw_wsol_with_session(
-    program_id: &Pubkey,
-    accounts: &[AccountInfo],
-    pool_tokens: u64,
-) -> ProgramResult {
-    // --- EXACT same order as WithdrawSol for the first 12/13 accounts ---
-    let ai = &mut accounts.iter();
-    let stake_pool_info           = next_account_info(ai)?; // 0  [w]
-    let withdraw_authority_info   = next_account_info(ai)?; // 1  []
-    let signer_or_session         = next_account_info(ai)?; // 2  [s] (user_transfer_authority)
-    let burn_from_pool_info       = next_account_info(ai)?; // 3  [w]
-    let reserve_stake_info        = next_account_info(ai)?; // 4  [w]
-    let user_wsol_ai              = next_account_info(ai)?; // 5  [w]  <-- destination
-    let manager_fee_info          = next_account_info(ai)?; // 6  [w]
-    let pool_mint_info            = next_account_info(ai)?; // 7  [w]
-    let clock_info                = next_account_info(ai)?; // 8  []
-    let stake_history_info        = next_account_info(ai)?; // 9  []
-    let stake_program_info        = next_account_info(ai)?; // 10 []
-    let token_program_info        = next_account_info(ai)?; // 11 []
+    fn process_withdraw_wsol_with_session(
+        program_id: &Pubkey,
+        accounts: &[AccountInfo],
+        pool_tokens: u64,
+    ) -> ProgramResult {
+        // --- EXACT same order as WithdrawSol for the first 12/13 accounts ---
+        let ai = &mut accounts.iter();
+        let stake_pool_info           = next_account_info(ai)?; // 0  [w]
+        let withdraw_authority_info   = next_account_info(ai)?; // 1  []
+        let signer_or_session         = next_account_info(ai)?; // 2  [s] (user_transfer_authority)
+        let burn_from_pool_info       = next_account_info(ai)?; // 3  [w]
+        let reserve_stake_info        = next_account_info(ai)?; // 4  [w]
+        let user_wsol_ai              = next_account_info(ai)?; // 5  [w]  <-- destination
+        let manager_fee_info          = next_account_info(ai)?; // 6  [w]
+        let pool_mint_info            = next_account_info(ai)?; // 7  [w]
+        let clock_info                = next_account_info(ai)?; // 8  []
+        let stake_history_info        = next_account_info(ai)?; // 9  []
+        let stake_program_info        = next_account_info(ai)?; // 10 []
+        let token_program_info        = next_account_info(ai)?; // 11 []
 
-    // --- Extra accounts for ATA creation / validation (AFTER the optional one) ---
-    // If you don't want on-chain creation, you can omit these and the creation block below.
-    let wsol_mint_ai              = next_account_info(ai)?; // 12 []
-    let fee_payer_ai              = next_account_info(ai)?; // 13 [s,w] payer for ATA (session or wallet)
-    let user_owner_ai             = next_account_info(ai)?; // 14 []   the user's system account (owner of ATA)
-    let system_program_ai         = next_account_info(ai)?; // 15 []
+        // --- Extra accounts for ATA creation / validation (AFTER the optional one) ---
+        // If you don't want on-chain creation, you can omit these and the creation block below.
+        let wsol_mint_ai              = next_account_info(ai)?; // 12 []
+        let fee_payer_ai              = next_account_info(ai)?; // 13 [s,w] payer for ATA (session or wallet)
+        let user_owner_ai             = next_account_info(ai)?; // 14 []   the user's system account (owner of ATA)
+        let system_program_ai         = next_account_info(ai)?; // 15 []
 
-    // Optional SOL withdraw authority (needs to be at the end since it is not always present)
-    let sol_withdraw_auth_res     = next_account_info(ai);  // 16 optional [s]
+        // Optional SOL withdraw authority (needs to be at the end since it is not always present)
+        let sol_withdraw_auth_res     = next_account_info(ai);  // 16 optional [s]
 
 
-    // ──────────────────────────────────────────────────────────────────────
-    // 1. Basic sanity checks
-    // ──────────────────────────────────────────────────────────────────────
+        // ──────────────────────────────────────────────────────────────────────
+        // 1. Basic sanity checks
+        // ──────────────────────────────────────────────────────────────────────
 
-    // Check that the WSOL mint is the native mint (So11111111111111111111111111111111111111112)
-    if *wsol_mint_ai.key != native_mint::id() {
-        msg!("WSOL mint: {:?}", wsol_mint_ai.key);
-        msg!("native mint: {:?}", native_mint::id());
-        msg!("WSOL mint must be the wrapped-SOL mint (So111…)");
-        return Err(ProgramError::InvalidAccountData);
-    }
-
-    // Who is the *real* user?
-    let user_pubkey = Session::extract_user_from_signer_or_session(
-        signer_or_session,
-        program_id,
-    )
-    .map_err(StakePoolError::from)?;
-
-    // Verify `user_wsol_ai` is that user’s ATA for WSOL
-    let expected_wsol_ata =
-        get_associated_token_address(&user_pubkey, wsol_mint_ai.key);
-    if expected_wsol_ata != *user_wsol_ai.key{
-        msg!("user_wsol_account is not the user's ATA for WSOL");
-        return Err(ProgramError::InvalidAccountData);
-    }
-
-    // ──────────────────────────────────────────────────────────────────────
-    // 2. Create the ATA if missing (idempotent)
-    // ──────────────────────────────────────────────────────────────────────
-
-    if user_wsol_ai.data_is_empty() {
-        // The associated-token-program create requires these accounts:
-        //   payer, associated_token, owner, mint, system_program, token_program
-        // Ensure payer is writable + signer in your instruction metas.
-        let create_ix =
-            spl_associated_token_account::instruction::create_associated_token_account(
-                fee_payer_ai.key,          // payer
-                &user_pubkey,              // owner of ATA
-                wsol_mint_ai.key,          // native mint
-                token_program_info.key,    // token program id
-            );
-        invoke(
-            &create_ix,
-            &[
-                fee_payer_ai.clone(),
-                user_wsol_ai.clone(),
-                user_owner_ai.clone(),     // == user_pubkey as a system account
-                wsol_mint_ai.clone(),
-                system_program_ai.clone(),
-                token_program_info.clone(),
-            ],
-        )?;
-    } else {
-        // Account exists, verify it's valid
-        let token_account = spl_token::state::Account::unpack(&user_wsol_ai.data.borrow())?;
-        if token_account.mint != *wsol_mint_ai.key || 
-        token_account.owner != user_pubkey {
-            msg!("Account already exists, but is invalid");
-            msg!("token_account.mint: {:?}", token_account.mint);
-            msg!("wsol_mint_ai.key: {:?}", wsol_mint_ai.key);
-            msg!("token_account.owner: {:?}", token_account.owner);
-            msg!("user_pubkey: {:?}", user_pubkey);
+        // Check that the WSOL mint is the native mint (So11111111111111111111111111111111111111112)
+        if *wsol_mint_ai.key != native_mint::id() {
+            msg!("WSOL mint: {:?}", wsol_mint_ai.key);
+            msg!("native mint: {:?}", native_mint::id());
+            msg!("WSOL mint must be the wrapped-SOL mint (So111…)");
             return Err(ProgramError::InvalidAccountData);
         }
+
+        // Who is the *real* user?
+        let user_pubkey = Session::extract_user_from_signer_or_session(
+            signer_or_session,
+            program_id,
+        )
+        .map_err(StakePoolError::from)?;
+
+        // Verify `user_wsol_ai` is that user’s ATA for WSOL
+        let expected_wsol_ata =
+            get_associated_token_address(&user_pubkey, wsol_mint_ai.key);
+        if expected_wsol_ata != *user_wsol_ai.key{
+            msg!("user_wsol_account is not the user's ATA for WSOL");
+            return Err(ProgramError::InvalidAccountData);
+        }
+
+        // ──────────────────────────────────────────────────────────────────────
+        // 2. Create the ATA if missing (idempotent)
+        // ──────────────────────────────────────────────────────────────────────
+
+        if user_wsol_ai.data_is_empty() {
+            // The associated-token-program create requires these accounts:
+            //   payer, associated_token, owner, mint, system_program, token_program
+            // Ensure payer is writable + signer in your instruction metas.
+            let create_ix =
+                spl_associated_token_account::instruction::create_associated_token_account(
+                    fee_payer_ai.key,          // payer
+                    &user_pubkey,              // owner of ATA
+                    wsol_mint_ai.key,          // native mint
+                    token_program_info.key,    // token program id
+                );
+            invoke(
+                &create_ix,
+                &[
+                    fee_payer_ai.clone(),
+                    user_wsol_ai.clone(),
+                    user_owner_ai.clone(),     // == user_pubkey as a system account
+                    wsol_mint_ai.clone(),
+                    system_program_ai.clone(),
+                    token_program_info.clone(),
+                ],
+            )?;
+        } else {
+            // Account exists, verify it's valid
+            let token_account = spl_token::state::Account::unpack(&user_wsol_ai.data.borrow())?;
+            if token_account.mint != *wsol_mint_ai.key || 
+            token_account.owner != user_pubkey {
+                msg!("Account already exists, but is invalid");
+                msg!("token_account.mint: {:?}", token_account.mint);
+                msg!("wsol_mint_ai.key: {:?}", wsol_mint_ai.key);
+                msg!("token_account.owner: {:?}", token_account.owner);
+                msg!("user_pubkey: {:?}", user_pubkey);
+                return Err(ProgramError::InvalidAccountData);
+            }
+        }
+
+        // ──────────────────────────────────────────────────────────────────────
+        // 3. Process the withdrawal
+        // ──────────────────────────────────────────────────────────────────────
+
+        // --- Rebuild the exact account slice for the inner WithdrawSol delegate ---
+        let mut withdraw_sol_accts: Vec<AccountInfo> = vec![
+            stake_pool_info.clone(),         // 0
+            withdraw_authority_info.clone(), // 1
+            signer_or_session.clone(),       // 2
+            burn_from_pool_info.clone(),     // 3
+            reserve_stake_info.clone(),      // 4
+            user_wsol_ai.clone(),            // 5 (destination)
+            manager_fee_info.clone(),        // 6
+            pool_mint_info.clone(),          // 7
+            clock_info.clone(),              // 8
+            stake_history_info.clone(),      // 9
+            stake_program_info.clone(),      // 10
+            token_program_info.clone(),      // 11
+        ];
+        if let Ok(sol_withdraw_auth_ai) = sol_withdraw_auth_res {
+            withdraw_sol_accts.push(sol_withdraw_auth_ai.clone()); // 12 optional
+        }
+
+        // --- Delegate to core withdraw: moves lamports to `user_wsol_ai` ----------
+        Self::process_withdraw_sol(program_id, &withdraw_sol_accts, pool_tokens, None)?;
+
+        // --- Sync native so token-amount reflects the lamports --------------------
+        let sync_ix = token_ix::sync_native(token_program_info.key, user_wsol_ai.key)?;
+        // Only the token account itself is required; no authority signer needed.
+        invoke(&sync_ix, &[user_wsol_ai.clone()])?;
+
+        Ok(())
     }
-
-    // ──────────────────────────────────────────────────────────────────────
-    // 3. Process the withdrawal
-    // ──────────────────────────────────────────────────────────────────────
-
-    // --- Rebuild the exact account slice for the inner WithdrawSol delegate ---
-    let mut withdraw_sol_accts: Vec<AccountInfo> = vec![
-        stake_pool_info.clone(),         // 0
-        withdraw_authority_info.clone(), // 1
-        signer_or_session.clone(),       // 2
-        burn_from_pool_info.clone(),     // 3
-        reserve_stake_info.clone(),      // 4
-        user_wsol_ai.clone(),            // 5 (destination)
-        manager_fee_info.clone(),        // 6
-        pool_mint_info.clone(),          // 7
-        clock_info.clone(),              // 8
-        stake_history_info.clone(),      // 9
-        stake_program_info.clone(),      // 10
-        token_program_info.clone(),      // 11
-    ];
-    if let Ok(sol_withdraw_auth_ai) = sol_withdraw_auth_res {
-        withdraw_sol_accts.push(sol_withdraw_auth_ai.clone()); // 12 optional
-    }
-
-    // --- Delegate to core withdraw: moves lamports to `user_wsol_ai` ----------
-    Self::process_withdraw_sol(program_id, &withdraw_sol_accts, pool_tokens, None)?;
-
-    // --- Sync native so token-amount reflects the lamports --------------------
-    let sync_ix = token_ix::sync_native(token_program_info.key, user_wsol_ai.key)?;
-    // Only the token account itself is required; no authority signer needed.
-    invoke(&sync_ix, &[user_wsol_ai.clone()])?;
-
-    Ok(())
-}
     
     /// Processes [`WithdrawSol`](enum.Instruction.html).
     #[inline(never)] // needed to avoid stack size violation


### PR DESCRIPTION
This PR adds support for instant withdrawals to WSOL.

The core change is to add an instruction `WithdrawWsolWithSession` which:

- Creates a WSOL ATA for the session user when it does not exist.
- Calls the existing `WithdrawSol` instruction with the WSOL ATA as the receiver.
- Syncs the WSOL ATA so it wraps its SOL balance to WSOL.

As part of this change we add client support for:

- CLI
- JS