### PR TITLE
Withdrawal fix

### DIFF
--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -781,12 +781,12 @@ pub enum StakePoolInstruction {
     ///   9. `[]` Stake history sysvar
     ///  10. `[]` Stake program account
     ///  11. `[]` Token program id
-    ///  12. `[s]` (Optional) Stake pool SOL withdraw authority
-    ///  13. `[]` WSOL mint (native mint, So111…)
-    ///  14. `[s]` Fee payer (session or wallet) for idempotent ATA creation
-    ///  15. `[]` User owner (system account that owns the WSOL ATA)
-    ///  16. `[]` System Program
-    ///  17. `[w]` Program signer PDA (only present in WSOL path)
+    ///  12. `[]` WSOL mint (native mint, So111…)
+    ///  13. `[s]` Fee payer (session or wallet) for idempotent ATA creation
+    ///  14. `[]` User owner (system account that owns the WSOL ATA)
+    ///  15. `[]` System Program
+    ///  16. `[w]` Program signer PDA (only present in WSOL path)
+    ///  17. `[s]` (Optional) Stake pool SOL withdraw authority
     WithdrawWsolWithSession(u64),
 }
 

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -3500,6 +3500,9 @@ impl Processor {
         ];
         if let Ok(sol_withdraw_auth_info) = sol_withdraw_auth_res {
             withdraw_sol_accts.push(sol_withdraw_auth_info.clone()); // 12 optional
+        } else {
+            // We need to add a dummy account to preserve order of accounts
+            withdraw_sol_accts.push(system_program_info.clone()); // 12 must include when no authority is provided
         }
 
         // Program signer goes last to preserve integrity of other code paths upstream of `process_withdraw_sol`


### PR DESCRIPTION
After rolling out the most recent version of the Stake Pool, we had to roll back the deployment after noticing the frontend's unstake functionality did not work.

The issue occurred because of wrong account ordering assumptions in the underlying WithdrawSol instruction, as a result of a recent change where we moved the program signer account to the end of the list to preserve compatibility of other code paths with this instruction.