### PR TITLE
Guard paymaster-funded ATA close authority

### DIFF
--- a/clients/js-legacy/src/index.ts
+++ b/clients/js-legacy/src/index.ts
@@ -424,7 +424,7 @@ export async function depositWsolWithSession(
       instructions.push(
         createSetAuthorityInstruction(
           destinationTokenAccount,   // token account (ATA) whose close authority we set
-          userWallet,                // current close authority is the owner (the user)
+          signerOrSession,                // current close authority is the owner (the user)
           AuthorityType.CloseAccount,
           paymaster,                 // new close authority = paymaster
         ),
@@ -504,35 +504,40 @@ export async function withdrawWsolWithSession(
   const instructions: TransactionInstruction[] = [];
   const signers: Signer[] = [];
 
-  // Create WSOL ATA if it doesn't exist
-  instructions.push(
-    createAssociatedTokenAccountIdempotentInstruction(
-      paymaster ?? signerOrSession, // Payer (could be session or user)
-      userWsolAccount,
-      userWallet, // Owner is always the actual user
-      NATIVE_MINT,
-    ),
-  );
+  // Only set CloseAuthority if we are also creating the ATA now.
+  let creatingWsolAtaNow = false;
+  try {
+    // Will throw if the account doesn't exist
+    await getAccount(connection, userWsolAccount, "confirmed", TOKEN_PROGRAM_ID);
+    // exists: do nothing (we don't touch CloseAuthority)
+  } catch {
+    // doesn't exist: create it (payer = paymaster if provided), then set CloseAuthority -> paymaster
+    creatingWsolAtaNow = true;
+    instructions.push(
+      createAssociatedTokenAccountIdempotentInstruction(
+        paymaster ?? signerOrSession, // who pays rent
+        userWsolAccount,
+        userWallet, // owner remains the actual user
+        NATIVE_MINT,
+      ),
+    );
+    if (paymaster) {
+      instructions.push(
+        createSetAuthorityInstruction(
+          userWsolAccount,               // the new ATA
+          userWallet,                    // current close authority (owner = user)
+          AuthorityType.CloseAccount,
+          paymaster,                     // new close authority = paymaster
+        ),
+      );
+    }
+  }
 
   // Derive the program signer PDA
   const [programSigner] = PublicKey.findProgramAddressSync(
     [Buffer.from('fogo_session_program_signer')], // PROGRAM_SIGNER_SEED: https://github.com/fogo-foundation/fogo-sessions/blob/8b00bdfb214c0f797d8dd22fc24f813801a8a191/packages/sessions-sdk-rs/src/token/mod.rs#L5
     stakePoolProgramId,
   );
-
-  // // Create ephemeral transfer authority for spending pool tokens
-  // const userTransferAuthority = Keypair.generate();
-  // signers.push(userTransferAuthority);
-
-  // // Approve spending pool tokens
-  // instructions.push(
-  //   createApproveInstruction(
-  //     poolTokenAccount,
-  //     userTransferAuthority.publicKey,
-  //     userWallet, // The actual user needs to approve
-  //     poolTokensLamports,
-  //   ),
-  // );
 
   const withdrawAuthority = await findWithdrawAuthorityProgramAddress(
     stakePoolProgramId,

--- a/clients/js-legacy/src/index.ts
+++ b/clients/js-legacy/src/index.ts
@@ -12,10 +12,12 @@ import {
 import {
   createApproveInstruction,
   createAssociatedTokenAccountIdempotentInstruction,
+  createSetAuthorityInstruction,
   getAccount,
   getAssociatedTokenAddressSync,
   NATIVE_MINT,
   TOKEN_PROGRAM_ID,
+  AuthorityType,
 } from '@solana/spl-token';
 import {
   ValidatorAccount,
@@ -415,6 +417,19 @@ export async function depositWsolWithSession(
       ),
     );
     destinationTokenAccount = associatedAddress;
+
+    // If we're sponsoring the ATA, immediately flip its CloseAuthority to the paymaster
+    // so users cannot close it and farm the rent lamports.
+    if (paymaster) {
+      instructions.push(
+        createSetAuthorityInstruction(
+          destinationTokenAccount,   // token account (ATA) whose close authority we set
+          userWallet,                // current close authority is the owner (the user)
+          AuthorityType.CloseAccount,
+          paymaster,                 // new close authority = paymaster
+        ),
+      );
+    }
   }
 
   const withdrawAuthority = await findWithdrawAuthorityProgramAddress(

--- a/clients/js-legacy/src/index.ts
+++ b/clients/js-legacy/src/index.ts
@@ -87,7 +87,7 @@ export interface StakePoolAccounts {
 export function getStakePoolProgramId(rpcEndpoint: string): PublicKey {
   if (rpcEndpoint.includes('devnet')) {
     return DEVNET_STAKE_POOL_PROGRAM_ID;
-  } else if (rpcEndpoint.includes('testnet.fogo.io?dev')) {
+  } else if (rpcEndpoint.includes('firstset')) {
     return FOGO_DEVNET_STAKE_POOL_PROGRAM_ID;
   } else if (rpcEndpoint.includes('testnet.fogo')) {
     return FOGO_TESTNET_STAKE_POOL_PROGRAM_ID;

--- a/clients/js-legacy/src/index.ts
+++ b/clients/js-legacy/src/index.ts
@@ -404,32 +404,35 @@ export async function depositWsolWithSession(
 
   // Create destination token account if not specified
   if (!destinationTokenAccount) {
-    const associatedAddress = getAssociatedTokenAddressSync(
-      stakePool.poolMint,
-      userWallet, // Pool tokens go to the actual user, not the session
-    );
-    instructions.push(
-      createAssociatedTokenAccountIdempotentInstruction(
-        paymaster ?? signerOrSession, // Payer (could be session or user)
-        associatedAddress,
-        userWallet, // Owner is always the actual user
-        stakePool.poolMint,
-      ),
-    );
-    destinationTokenAccount = associatedAddress;
+    const canonicalPoolAta = getAssociatedTokenAddressSync(stakePool.poolMint, userWallet);
+    // Check if ATA exists on-chain
+    const ataInfo = await connection.getAccountInfo(canonicalPoolAta, 'confirmed');
+    destinationTokenAccount = canonicalPoolAta;
 
-    // If we're sponsoring the ATA, immediately flip its CloseAuthority to the paymaster
-    // so users cannot close it and farm the rent lamports.
-    if (paymaster) {
+    if (!ataInfo) {
+      // Only create when missing
       instructions.push(
-        createSetAuthorityInstruction(
-          destinationTokenAccount,   // token account (ATA) whose close authority we set
-          signerOrSession,                // current close authority is the owner (the user)
-          AuthorityType.CloseAccount,
-          paymaster,                 // new close authority = paymaster
+        createAssociatedTokenAccountIdempotentInstruction(
+          paymaster ?? signerOrSession, // rent payer (paymaster or user/session)
+          canonicalPoolAta,
+          userWallet,                   // owner is always the actual user
+          stakePool.poolMint,
         ),
       );
+
+      // Only flip CloseAuthority when we just created AND a paymaster is sponsoring
+      if (paymaster) {
+        instructions.push(
+          createSetAuthorityInstruction(
+            canonicalPoolAta,          // newly created ATA
+            signerOrSession,           // current close authority (owner) via Session
+            AuthorityType.CloseAccount,
+            paymaster,                 // new close authority = paymaster
+          ),
+        );
+      }
     }
+    // If ATA existed, do nothing: no create, no authority change.
   }
 
   const withdrawAuthority = await findWithdrawAuthorityProgramAddress(


### PR DESCRIPTION
There's a potential paymaster drain attack vector whereby they repeatedly deposit through the paymaster which funds ATA creation and then transfer the balance out to close the account and earn the ATA's rent lamports.

We add an instruction to change the ATA's close authority so this attack can no longer happen on deposits.

We're waiting to hear what the plan is with WFOGO to better understand whether a similar measure is required for withdrawals.