### PR TITLE
Bugfix: Mitigate DOS vector in DepositWsolWithSession

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,7 +8,6 @@ jobs:
   format_and_lint_programs:
     name: Format & Lint Programs
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.changed_files, 'programs/') || contains(github.event.pull_request.changed_files, 'clients/py')
     steps:
       - name: Git Checkout
         uses: actions/checkout@v4
@@ -28,7 +27,6 @@ jobs:
   format_and_lint_client_js:
     name: Format & Lint Client JS
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.changed_files, 'clients/js-legacy/')
     steps:
       - name: Git Checkout
         uses: actions/checkout@v4
@@ -45,7 +43,6 @@ jobs:
   format_and_lint_cli:
     name: Format & Lint CLI
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.changed_files, 'clients/cli/')
     steps:
       - name: Git Checkout
         uses: actions/checkout@v4
@@ -107,7 +104,6 @@ jobs:
     name: Build programs
     runs-on: ubuntu-latest
     needs: format_and_lint_programs
-    if: contains(github.event.pull_request.changed_files, 'programs/')
     steps:
       - name: Git Checkout
         uses: actions/checkout@v4
@@ -138,7 +134,6 @@ jobs:
     name: Test Programs
     runs-on: ubuntu-latest
     needs: format_and_lint_programs
-    if: contains(github.event.pull_request.changed_files, 'programs/')
     steps:
       - name: Git Checkout
         uses: actions/checkout@v4
@@ -157,7 +152,6 @@ jobs:
   test_client_js:
     name: Test Client JS
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.changed_files, 'clients/js-legacy/')
     steps:
       - name: Git Checkout
         uses: actions/checkout@v4
@@ -173,7 +167,6 @@ jobs:
   test_client_cli:
     name: Test Client CLI
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.changed_files, 'clients/cli/')
     steps:
       - name: Git Checkout
         uses: actions/checkout@v4

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -2685,12 +2685,12 @@ impl Processor {
 
         // This helper creates the account or tops it up with enough rent-exempt lamports when needed if it exists already.
         create_pda_account(
-            &fee_payer_info,                // payer (wallet or session key)
+            fee_payer_info,                 // payer (wallet or session key)
             &rent,                          // rent-exempt lamports
             spl_token::state::Account::LEN, // space for a token account
-            &token_program_info.key,        // OWNER **must** be SPL-Token!
-            &system_program_info,
-            &transient_wsol_info, // new account address (PDA)
+            token_program_info.key,         // OWNER **must** be SPL-Token!
+            system_program_info,
+            transient_wsol_info, // new account address (PDA)
             transient_seeds,
         )?;
 

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -41,7 +41,9 @@ use {
         stake, system_instruction, system_program,
         sysvar::Sysvar,
     },
-    spl_associated_token_account::{get_associated_token_address, tools::account::create_pda_account},
+    spl_associated_token_account::{
+        get_associated_token_address, tools::account::create_pda_account,
+    },
     spl_token::{instruction as token_ix, native_mint},
     spl_token_2022::{
         check_spl_token_program_account,
@@ -2680,15 +2682,15 @@ impl Processor {
 
         // Create a temporary WSOL account for the session
         let rent = Rent::get()?;
-        
+
         // This helper creates the account or tops it up with enough rent-exempt lamports when needed if it exists already.
         create_pda_account(
-            &fee_payer_info,                    // payer (wallet or session key)
-            &rent,                         // rent-exempt lamports
+            &fee_payer_info,                // payer (wallet or session key)
+            &rent,                          // rent-exempt lamports
             spl_token::state::Account::LEN, // space for a token account
-            &token_program_info.key,                // OWNER **must** be SPL-Token!
+            &token_program_info.key,        // OWNER **must** be SPL-Token!
             &system_program_info,
-            &transient_wsol_info,               // new account address (PDA)
+            &transient_wsol_info, // new account address (PDA)
             transient_seeds,
         )?;
 

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -41,7 +41,7 @@ use {
         stake, system_instruction, system_program,
         sysvar::Sysvar,
     },
-    spl_associated_token_account::get_associated_token_address,
+    spl_associated_token_account::{get_associated_token_address, tools::account::create_pda_account},
     spl_token::{instruction as token_ix, native_mint},
     spl_token_2022::{
         check_spl_token_program_account,
@@ -2660,13 +2660,6 @@ impl Processor {
         // 2. Create and initialize a temporary WSOL account controlled by the program
         // ──────────────────────────────────────────────────────────────────────
 
-        // PDA must not exist yet
-        // This is safe because we always close it later on, and it is not created anywhere else
-        if !transient_wsol_info.data_is_empty() {
-            msg!("transient_wsol PDA already exists; must be fresh each call");
-            return Err(ProgramError::InvalidAccountData);
-        }
-
         // ──────────────────────────────────────────────────────────────────────
         // a) Create the account – owner = SPL Token program
         // ──────────────────────────────────────────────────────────────────────
@@ -2682,31 +2675,21 @@ impl Processor {
             return Err(ProgramError::InvalidSeeds);
         }
 
-        // Create a temporary WSOL account for the session
-        let rent = Rent::get()?;
-        let rent_lamports = rent.minimum_balance(spl_token::state::Account::LEN);
-        let create_ix = solana_program::system_instruction::create_account(
-            fee_payer_info.key,                    // payer (wallet or session key)
-            transient_wsol_info.key,               // new account address (PDA)
-            rent_lamports,                         // rent-exempt lamports
-            spl_token::state::Account::LEN as u64, // space for a token account
-            token_program_info.key,                // OWNER **must** be SPL-Token!
-        );
-
         let transient_seeds: &[&[u8]] =
             &[b"transient_wsol", user_pubkey.as_ref(), &[transient_bump]];
 
-        // The *payer* (`signer_or_session_info`) already signed the outer tx,
-        // but the NEW account (a PDA) must also appear as a signer – therefore
-        // we invoke with `invoke_signed` and pass `transient_seeds`.
-        invoke_signed(
-            &create_ix,
-            &[
-                fee_payer_info.clone(),      // payer
-                transient_wsol_info.clone(), // new account
-                system_program_info.clone(),
-            ],
-            &[transient_seeds],
+        // Create a temporary WSOL account for the session
+        let rent = Rent::get()?;
+        
+        // This helper creates the account or tops it up with enough rent-exempt lamports when needed if it exists already.
+        create_pda_account(
+            &fee_payer_info,                    // payer (wallet or session key)
+            &rent,                         // rent-exempt lamports
+            spl_token::state::Account::LEN, // space for a token account
+            &token_program_info.key,                // OWNER **must** be SPL-Token!
+            &system_program_info,
+            &transient_wsol_info,               // new account address (PDA)
+            transient_seeds,
         )?;
 
         // ──────────────────────────────────────────────────────────────────────
@@ -2801,6 +2784,9 @@ impl Processor {
         // ──────────────────────────────────────────────────────────────────────
         // 5. Refund rent
         // ──────────────────────────────────────────────────────────────────────
+
+        // We assume the paymaster is always covering the full cost of the transient ATA creation.
+        let rent_lamports = rent.minimum_balance(spl_token::state::Account::LEN);
 
         let refund_ix = solana_program::system_instruction::transfer(
             program_signer_info.key,


### PR DESCRIPTION
Neodyme flagged a DOS attack vector in the `DepositWsolWithSession` code path whereby an attacker could block users from successfully depositing if their corresponding transient WSOL ATA that the program needs to create in order to process deposits via the paymaster is already existent.

The program creates and destroys these ATAs throughout the instruction's execution and assumes no one else is creating them and leaving them open, otherwise it rejects the deposit.

We have been advised to instead create the ATA via the `create_pda_account` utility function in the ATA crate https://github.com/solana-program/associated-token-account/blob/main/program/src/tools/account.rs

I have deployed this patch on staging and tested that it works: https://fogoscan.com/tx/4Bc1Kiye6mGCitMbAAn6cK6aS7qovdoqdtvvSgJCQJT7pAoBp3wsR7VHrbUNrdRRfgeHzFuSR27CWexnhVEYThwE?cluster=testnet