### PR TITLE
feat: define program ID via env for the rebalance bot

### DIFF
--- a/clients/py/stake_pool/constants.py
+++ b/clients/py/stake_pool/constants.py
@@ -1,12 +1,18 @@
 """SPL Stake Pool Constants."""
 
+import os
 from typing import Optional, Tuple
 
 from solders.pubkey import Pubkey
 from stake.constants import MINIMUM_DELEGATION
 
-STAKE_POOL_PROGRAM_ID = Pubkey.from_string("SPRe2ae9JQhySheYsSANX6M8tUZLt5bQonnBJ6Wu6Ud")
-"""Public key that identifies the SPL Stake Pool program."""
+_STAKE_POOL_PROGRAM_ID_STR = os.environ.get(
+    "STAKE_POOL_PROGRAM_ID",
+    "SPRe2ae9JQhySheYsSANX6M8tUZLt5bQonnBJ6Wu6Ud",  # use the testnet program ID by default
+)
+
+STAKE_POOL_PROGRAM_ID = Pubkey.from_string(_STAKE_POOL_PROGRAM_ID_STR)
+"""Public key that identifies the SPL Stake Pool program (env override: STAKE_POOL_PROGRAM_ID)."""
 
 MAX_VALIDATORS_TO_UPDATE: int = 4
 """Maximum number of validators to update during UpdateValidatorListBalance."""
@@ -47,14 +53,14 @@ def find_stake_program_address(
     program_id: Pubkey,
     vote_account_address: Pubkey,
     stake_pool_address: Pubkey,
-    seed: Optional[int]
+    seed: Optional[int],
 ) -> Tuple[Pubkey, int]:
     """Generates the stake program address for a validator's vote account"""
     return Pubkey.find_program_address(
         [
             bytes(vote_account_address),
             bytes(stake_pool_address),
-            seed.to_bytes(4, 'little') if seed else bytes(),
+            seed.to_bytes(4, "little") if seed else bytes(),
         ],
         program_id,
     )
@@ -72,40 +78,31 @@ def find_transient_stake_program_address(
             TRANSIENT_STAKE_SEED_PREFIX,
             bytes(vote_account_address),
             bytes(stake_pool_address),
-            seed.to_bytes(8, 'little'),
+            seed.to_bytes(8, "little"),
         ],
         program_id,
     )
 
 
 def find_ephemeral_stake_program_address(
-    program_id: Pubkey,
-    stake_pool_address: Pubkey,
-    seed: int
+    program_id: Pubkey, stake_pool_address: Pubkey, seed: int
 ) -> Tuple[Pubkey, int]:
-
     """Generates the ephemeral program address for stake pool redelegation"""
     return Pubkey.find_program_address(
         [
             EPHEMERAL_STAKE_SEED_PREFIX,
             bytes(stake_pool_address),
-            seed.to_bytes(8, 'little'),
+            seed.to_bytes(8, "little"),
         ],
         program_id,
     )
 
 
-def find_metadata_account(
-    mint_key: Pubkey
-) -> Tuple[Pubkey, int]:
+def find_metadata_account(mint_key: Pubkey) -> Tuple[Pubkey, int]:
     """Generates the metadata account program address"""
     return Pubkey.find_program_address(
-        [
-            METADATA_SEED_PREFIX,
-            bytes(METADATA_PROGRAM_ID),
-            bytes(mint_key)
-        ],
-        METADATA_PROGRAM_ID
+        [METADATA_SEED_PREFIX, bytes(METADATA_PROGRAM_ID), bytes(mint_key)],
+        METADATA_PROGRAM_ID,
     )
 
 
@@ -117,5 +114,5 @@ TRANSIENT_STAKE_SEED_PREFIX = b"transient"
 """Seed used to derive transient stake accounts."""
 METADATA_SEED_PREFIX = b"metadata"
 """Seed used to avoid certain collision attacks."""
-EPHEMERAL_STAKE_SEED_PREFIX = b'ephemeral'
+EPHEMERAL_STAKE_SEED_PREFIX = b"ephemeral"
 """Seed for ephemeral stake account"""


### PR DESCRIPTION
In this way we can run several systemd services for different environments using the same code base. For example:

```
# for devnet
# /etc/systemd/system/fogo-staging-stake-pool-crank.service
[Unit]
Description=Fogo Testnet Stake Pool Crank Service
After=network.target

[Service]
Type=simple
User=root
WorkingDirectory=/root/stake-pool-v2/clients/py
Environment=PYTHONUNBUFFERED=1
Environment=STAKE_POOL_PROGRAM_ID=SDbhNGbX66AFP9RPa3m8v1XooCCb5mbutk2NiVxdTw4
ExecStart=/root/stake-pool-v2/clients/py/venv/bin/python -m bot.rebalance --endpoint https://testnet.fogo.io 5wL3K4ACX3pZqg2Aq9cxxPCe9eSoc5c6dBGnhXaPkPMk /root/fogo-pool-staker.json --reserve_amount 0.1 --reserve_percent 0 --service
Restart=on-failure
RestartSec=5

[Install]
WantedBy=multi-user.target
```