### PR TITLE
feat: add Fogo mainnet stake pool program ID to JS SDK

### DIFF
--- a/clients/js-legacy/src/constants.ts
+++ b/clients/js-legacy/src/constants.ts
@@ -25,6 +25,11 @@ export const FOGO_DEVNET_STAKE_POOL_PROGRAM_ID = new PublicKey(
   'SDbhNGbX66AFP9RPa3m8v1XooCCb5mbutk2NiVxdTw4',
 );
 
+// Public key that identifies the SPL Stake Pool program deployed to Fogo mainnet.
+export const FOGO_MAINNET_STAKE_POOL_PROGRAM_ID = new PublicKey(
+  'SPoo1G3scVhcVWK8RHF2GhauFgbg3aiPNeU5d5Adr8D',
+);
+
 // Maximum number of validators to update during UpdateValidatorListBalance.
 export const MAX_VALIDATORS_TO_UPDATE = 4;
 

--- a/clients/js-legacy/src/index.ts
+++ b/clients/js-legacy/src/index.ts
@@ -48,12 +48,19 @@ import {
   DEVNET_STAKE_POOL_PROGRAM_ID,
   FOGO_TESTNET_STAKE_POOL_PROGRAM_ID,
   FOGO_DEVNET_STAKE_POOL_PROGRAM_ID,
+  FOGO_MAINNET_STAKE_POOL_PROGRAM_ID,
 } from './constants';
 import { create } from 'superstruct';
 import BN from 'bn.js';
 
 export type { StakePool, AccountType, ValidatorList, ValidatorStakeInfo } from './layouts';
-export { DEVNET_STAKE_POOL_PROGRAM_ID, STAKE_POOL_PROGRAM_ID } from './constants';
+export {
+  DEVNET_STAKE_POOL_PROGRAM_ID,
+  STAKE_POOL_PROGRAM_ID,
+  FOGO_TESTNET_STAKE_POOL_PROGRAM_ID,
+  FOGO_DEVNET_STAKE_POOL_PROGRAM_ID,
+  FOGO_MAINNET_STAKE_POOL_PROGRAM_ID,
+} from './constants';
 export * from './instructions';
 export { StakePoolLayout, ValidatorListLayout, ValidatorStakeInfoLayout } from './layouts';
 
@@ -83,12 +90,15 @@ export interface StakePoolAccounts {
 }
 
 export function getStakePoolProgramId(rpcEndpoint: string): PublicKey {
-  if (rpcEndpoint.includes('devnet')) {
-    return DEVNET_STAKE_POOL_PROGRAM_ID;
+  if (rpcEndpoint.includes('testnet.fogo')) {
+    return FOGO_TESTNET_STAKE_POOL_PROGRAM_ID;
   } else if (rpcEndpoint.includes('firstset')) {
     return FOGO_DEVNET_STAKE_POOL_PROGRAM_ID;
-  } else if (rpcEndpoint.includes('testnet.fogo')) {
-    return FOGO_TESTNET_STAKE_POOL_PROGRAM_ID;
+  } else if (rpcEndpoint.includes('fogo')) {
+    // Fogo mainnet (e.g., mainnet.fogo.io or fogo.io)
+    return FOGO_MAINNET_STAKE_POOL_PROGRAM_ID;
+  } else if (rpcEndpoint.includes('devnet')) {
+    return DEVNET_STAKE_POOL_PROGRAM_ID;
   } else {
     return STAKE_POOL_PROGRAM_ID;
   }


### PR DESCRIPTION
Update getStakePoolProgramId() to detect Fogo mainnet RPC endpoints and return the correct program ID (SPoo1G3scVhcVWK8RHF2GhauFgbg3aiPNeU5d5Adr8D) instead of falling through to the Solana mainnet program ID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)