### PR TITLE
improve the robustness of rebalancing bot

### DIFF
--- a/clients/py/bot/rebalance.py
+++ b/clients/py/bot/rebalance.py
@@ -209,7 +209,6 @@ async def service_mode(
     dry_run: bool = False,
 ):
     async_client = await get_client(endpoint)
-    current_epoch = None
     rebalanced_in_current_epoch = False
     print("Starting service mode - monitoring epoch progress...")
 
@@ -219,12 +218,32 @@ async def service_mode(
 
             print(f"Current epoch: {epoch}, progress: {progress:.2%}")
 
-            if epoch != current_epoch:
-                print(f"New epoch detected: {epoch} (previous: {current_epoch})")
-                print(f"Updating stake pool for new epoch {epoch}")
-                await update_stake_pool(async_client, staker, stake_pool_address)
-                print(f"Updating stake pool for new epoch {epoch} done")
-                current_epoch = epoch
+            resp = await async_client.get_account_info(
+                stake_pool_address, commitment=Confirmed
+            )
+            data = resp.value.data if resp.value else bytes()
+            stake_pool = StakePool.decode(data)
+
+            print(
+                f"Stake pool last update epoch {stake_pool.last_update_epoch}, current epoch {epoch}"
+            )
+
+            if stake_pool.last_update_epoch != epoch:
+                print(f"The pool has not been updated for epoch {epoch} yet")
+                print(f"Updating stake pool for epoch {epoch}")
+                try:
+                    await update_stake_pool(async_client, staker, stake_pool_address)
+                    print(f"Updating stake pool for epoch {epoch} done")
+                except Exception as e:
+                    print(f"Error when updating the pool: {e}")
+                    # one of the potential reasons is there are some transient stake accounts in an unexpected state
+                    # for example, the total amount of stakes to be activated hits the epoch warming up limit and it takes more epochs to become fully active
+                    # in this case, we retry to update the pool without merging the stake accounts
+                    # ref: https://docs.anza.xyz/consensus/stake-delegation-and-rewards#stake-warmup-cooldown-withdrawal
+                    await update_stake_pool(
+                        async_client, staker, stake_pool_address, True
+                    )
+                    print(f"Updating stake pool without merges for epoch {epoch} done")
                 rebalanced_in_current_epoch = False
 
             if progress >= 0.95 and not rebalanced_in_current_epoch:

--- a/clients/py/stake_pool/actions.py
+++ b/clients/py/stake_pool/actions.py
@@ -417,7 +417,7 @@ async def withdraw_stake(
     await client.send_transaction(txn, opts=OPTS)
 
 
-async def update_stake_pool(client: AsyncClient, payer: Keypair, stake_pool_address: Pubkey):
+async def update_stake_pool(client: AsyncClient, payer: Keypair, stake_pool_address: Pubkey, no_merge=False):
     """Create and send all instructions to completely update a stake pool after epoch change."""
     resp = await client.get_account_info(stake_pool_address, commitment=Confirmed)
     data = resp.value.data if resp.value else bytes()
@@ -462,7 +462,7 @@ async def update_stake_pool(client: AsyncClient, payer: Keypair, stake_pool_addr
                     stake_program_id=STAKE_PROGRAM_ID,
                     validator_and_transient_stake_pairs=validator_and_transient_stake_pairs,
                     start_index=start_index,
-                    no_merge=False,
+                    no_merge=no_merge,
                 )
             )
         )


### PR DESCRIPTION
The bot falls back to update the pool without performing merges when transient stakes are not ready to be merged yet, this is helpful when there is a huge amount of new stakes in an epoch and they cannot become fully active after crossing one epoch boundary.

Explanations can be found here:
- https://www.solana-program.com/docs/stake-pool/cli#update
- https://solana.com/docs/references/staking/stake-accounts?utm_source=chatgpt.com#delegation-warmup-and-cooldown